### PR TITLE
Improved I2C scan for LCD not found

### DIFF
--- a/Firmware/GPAD_Factory_Test/GPAD_Factory_Test.ino
+++ b/Firmware/GPAD_Factory_Test/GPAD_Factory_Test.ino
@@ -125,22 +125,22 @@ void scanI2C(void) {
   Serial.println ("I2C scanner. Scanning ...");
 
   const byte scanStart = 8;
-  const byte scanEnd = 100;
+  const byte scanEnd = 120;
   const byte scanRange = scanEnd - scanStart;
   byte endCode[6] = { 0 };    // returns no. of addresses per return code (max 6 codes).
 
   Wire.begin();
   for (byte i = scanStart; i < scanEnd; i++)  // scan fully range of addresses
   {
-    Wire.beginTransmission(i);
+    Wire.beginTransmission (i);
     endCode[Wire.endTransmission()]++;  // tally up return codes
     if (Wire.endTransmission() == SUCCESS) {
-      Serial.print("Found address: ");
-      Serial.print(i, DEC);
-      Serial.print(" (0x");
-      Serial.print(i, HEX);
-      Serial.println(")");
-      delay(1);  // maybe unneeded?
+      Serial.print ("Found address: ");
+      Serial.print (i, DEC);
+      Serial.print (" (0x");
+      Serial.print (i, HEX);
+      Serial.println (")");
+      delay (1);  // maybe unneeded?
     } // end of good response
   } // end of for loop
   Serial.println ("Done.");


### PR DESCRIPTION
This change addresses #89 by supplementing the output on the Serial Port with error codes. If the I2C LCD is not found, at least one error message (of five) will be displayed. Simulated it using the WokWi simulator, as recommended.

Included in the error message is the number of scanned addresses pertaining to that error code just in case the number of faulty I²C peripherals is more than one or a particular address is playing up. 

Return codes for the method endTransmission() have been referenced from the official Arduino website.

Good first issue? GREAT first issue. Cheers!

NULLbodyHERE [nullbody.h@gmail.com]